### PR TITLE
Made Forum channel background transparent

### DIFF
--- a/src/_base.scss
+++ b/src/_base.scss
@@ -64,7 +64,9 @@ body {
 .stickyHeader-fX4ei6,
 .scroller-1TOeMq,
 // The Explore servers page
-.pageWrapper-2PwDoS {
+.pageWrapper-2PwDoS,
+// The Forum page 
+.container-3wLKDe {
     background: transparent !important;
 }
 


### PR DESCRIPTION
The forum channel still had it's default discord color background. This change fixes that issue.

Before:
![image](https://user-images.githubusercontent.com/44726280/226654034-12a82844-a975-4b4f-aacb-cb561a8ec0cd.png)

After:
![image](https://user-images.githubusercontent.com/44726280/226654259-fe1466d8-2a67-416d-aba6-c64d54bf05f2.png)
